### PR TITLE
fix: Corrige renderização das páginas do blog para compartilhamento

### DIFF
--- a/alissonlimabr/.gitignore
+++ b/alissonlimabr/.gitignore
@@ -48,4 +48,7 @@ src/environments/environment.prod.ts
 # RSS — gerado em build pelo scripts/generate-rss.mjs
 src/rss.xml
 
+# Rotas — gerado em build pelo scripts/generate-routes.mjs
+routes.txt
+
 api/dist

--- a/alissonlimabr/angular.json
+++ b/alissonlimabr/angular.json
@@ -122,7 +122,7 @@
           "builder": "@angular-devkit/build-angular:server",
           "options": {
             "outputPath": "dist/alissonlimabr/server",
-            "main": "server.ts",
+            "main": "src/main.server.ts",
             "tsConfig": "tsconfig.server.json",
             "inlineStyleLanguage": "scss"
           },

--- a/alissonlimabr/package.json
+++ b/alissonlimabr/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "prerender": "ng run alissonlimabr:prerender"
+    "prerender": "node scripts/generate-routes.mjs && ng build --configuration production && ng run alissonlimabr:server:production && node scripts/prerender.mjs"
   },
   "private": true,
   "dependencies": {

--- a/alissonlimabr/scripts/generate-routes.mjs
+++ b/alissonlimabr/scripts/generate-routes.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Generates every route that needs static HTML during the Vercel build.
+
+import { writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const target = resolve(__dirname, '..', 'routes.txt');
+
+const PROJECT_ID = process.env.SANITY_PROJECT_ID;
+const DATASET = process.env.SANITY_DATASET || 'production';
+const API_VERSION = process.env.SANITY_API_VERSION || '2025-05-20';
+
+if (!PROJECT_ID) {
+  console.error('[generate-routes] SANITY_PROJECT_ID is required to prerender blog routes.');
+  process.exit(1);
+}
+
+const safeConfigValue = /^[A-Za-z0-9_.-]+$/;
+for (const [key, value] of Object.entries({ PROJECT_ID, DATASET, API_VERSION })) {
+  if (!safeConfigValue.test(value)) {
+    console.error(`[generate-routes] Invalid value for ${key}: "${value}"`);
+    process.exit(1);
+  }
+}
+
+const groq = `{
+  "posts": *[_type == "post" && defined(slug.current)].slug.current,
+  "categories": *[_type == "category" && defined(slug.current)].slug.current
+}`;
+const queryUrl = `https://${PROJECT_ID}.apicdn.sanity.io/v${API_VERSION}/data/query/${DATASET}?query=${encodeURIComponent(groq)}`;
+
+let content;
+try {
+  const response = await fetch(queryUrl, { signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  content = (await response.json()).result || {};
+} catch (err) {
+  console.error(`[generate-routes] Failed to query Sanity: ${err.message}`);
+  process.exit(1);
+}
+
+const validateSlugs = (slugs, type) =>
+  (slugs || []).map(slug => {
+    if (typeof slug !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(slug)) {
+      throw new Error(`Invalid ${type} slug returned by Sanity: "${slug}"`);
+    }
+    return slug;
+  });
+
+let posts;
+let categories;
+try {
+  posts = validateSlugs(content.posts, 'post').sort();
+  categories = validateSlugs(content.categories, 'category').sort();
+} catch (err) {
+  console.error(`[generate-routes] ${err.message}`);
+  process.exit(1);
+}
+
+const routes = new Set([
+  '/',
+  '/blog',
+  '/blog/categorias',
+  ...posts.map(slug => `/blog/${slug}`),
+  ...categories.map(slug => `/blog/categoria/${slug}`),
+]);
+
+writeFileSync(target, `${Array.from(routes).join('\n')}\n`, 'utf8');
+console.log(`[generate-routes] routes.txt generated with ${routes.size} routes.`);

--- a/alissonlimabr/scripts/prerender.mjs
+++ b/alissonlimabr/scripts/prerender.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Renders static route HTML without the legacy Angular prerender worker.
+
+import { createRequire } from 'node:module';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const routesPath = join(root, 'routes.txt');
+const browserPath = join(root, 'dist', 'alissonlimabr', 'browser');
+const serverBundlePath = join(root, 'dist', 'alissonlimabr', 'server', 'main.js');
+
+const require = createRequire(import.meta.url);
+const serverExports = require(serverBundlePath);
+const { AppServerModule, renderModule, ɵSERVER_CONTEXT: SERVER_CONTEXT } = serverExports;
+
+if (!AppServerModule || typeof renderModule !== 'function' || !SERVER_CONTEXT) {
+  console.error('[prerender] The server bundle does not export AppServerModule and Angular renderModule.');
+  process.exit(1);
+}
+
+const [document, routeText] = await Promise.all([
+  readFile(join(browserPath, 'index.html'), 'utf8'),
+  readFile(routesPath, 'utf8'),
+]);
+
+const routes = routeText
+  .split(/\r?\n/)
+  .map(route => route.trim())
+  .filter(Boolean);
+
+const routePattern = /^\/(?:[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*)?$/;
+for (const route of routes) {
+  if (!routePattern.test(route)) {
+    console.error(`[prerender] Invalid route in routes.txt: "${route}"`);
+    process.exit(1);
+  }
+}
+
+for (const route of routes) {
+  try {
+    const html = await renderModule(AppServerModule, {
+      document,
+      url: route,
+      extraProviders: [
+        { provide: SERVER_CONTEXT, useValue: 'ssg' },
+      ],
+    });
+    const destination = route === '/'
+      ? join(browserPath, 'index.html')
+      : join(browserPath, route.slice(1), 'index.html');
+    await mkdir(dirname(destination), { recursive: true });
+    await writeFile(destination, html, 'utf8');
+    console.log(`[prerender] rendered ${route}`);
+  } catch (err) {
+    console.error(`[prerender] Failed to render ${route}:`, err);
+    process.exit(1);
+  }
+}
+
+console.log(`[prerender] Static HTML generated for ${routes.length} routes.`);

--- a/alissonlimabr/src/app/app.module.ts
+++ b/alissonlimabr/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
@@ -13,7 +13,7 @@ import { AppComponent } from './app.component';
     AppComponent,
   ],
   providers: [
-    provideHttpClient(withInterceptorsFromDi()),
+    provideHttpClient(withFetch(), withInterceptorsFromDi()),
   ],
   bootstrap: [AppComponent],
 })

--- a/alissonlimabr/src/app/blog/blog-post/blog-post.component.ts
+++ b/alissonlimabr/src/app/blog/blog-post/blog-post.component.ts
@@ -8,12 +8,13 @@ import {
   NgZone,
   OnDestroy,
   OnInit,
+  PLATFORM_ID,
   ViewChild,
   ViewEncapsulation,
   inject,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { DOCUMENT } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { DomSanitizer, Meta, SafeHtml, Title } from '@angular/platform-browser';
 import { switchMap } from 'rxjs';
@@ -47,6 +48,7 @@ import { IconComponent } from '../../shared/icon.component';
 })
 export class BlogPostComponent implements OnInit, OnDestroy {
   private readonly destroyRef = inject(DestroyRef);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   post?: Post;
   bodyHtml?: SafeHtml;
@@ -63,6 +65,7 @@ export class BlogPostComponent implements OnInit, OnDestroy {
   private jsonLdScript?: HTMLScriptElement;
   private scrollCleanup?: () => void;
   private readonly siteOrigin = 'https://alissonlimadev.com';
+  private readonly defaultOgImageUrl = 'https://homolog.alissonlimadev.com/assets/img/og-image.webp';
 
   constructor(
     private route: ActivatedRoute,
@@ -97,8 +100,9 @@ export class BlogPostComponent implements OnInit, OnDestroy {
             if (post.imageUrl && !/^https?:\/\//i.test(post.imageUrl)) {
               post.imageUrl = undefined;
             }
+            const socialImageUrl = post.ogImageUrl || post.imageUrl;
             post.imageUrl = this.sanity.optimizeImageUrl(post.imageUrl, { w: 1200, h: 675 });
-            post.ogImageUrl = this.sanity.optimizeImageUrl(post.ogImageUrl, { w: 1200, h: 630 });
+            post.ogImageUrl = this.sanity.optimizeImageUrl(socialImageUrl, { w: 1200, h: 630 });
 
             this.post = post;
             this.bodyHtml = this.sanitizer.bypassSecurityTrustHtml(
@@ -115,11 +119,13 @@ export class BlogPostComponent implements OnInit, OnDestroy {
             this.setCanonical(post.slug.current);
             this.loadRelatedPosts(post.slug.current, post.tags ?? []);
 
-            window.scrollTo({ top: 0, behavior: 'auto' });
-            setTimeout(() => {
-              this.enhanceCodeBlocks();
-              this.buildToc();
-            }, 0);
+            if (this.isBrowser) {
+              window.scrollTo({ top: 0, behavior: 'auto' });
+              setTimeout(() => {
+                this.enhanceCodeBlocks();
+                this.buildToc();
+              }, 0);
+            }
           });
         },
         error: () => {
@@ -161,7 +167,7 @@ export class BlogPostComponent implements OnInit, OnDestroy {
 
   private applySeo(post: Post): void {
     const description = (post.seoDescription || post.excerpt || '').slice(0, 160);
-    const imageUrl = post.ogImageUrl || post.imageUrl || '';
+    const imageUrl = post.ogImageUrl || post.imageUrl || this.defaultOgImageUrl;
     const title = `${post.title} | Alisson Lima Dev`;
     const url = `${this.siteOrigin}/blog/${post.slug.current}`;
 
@@ -171,15 +177,13 @@ export class BlogPostComponent implements OnInit, OnDestroy {
     this.metaService.updateTag({ property: 'og:title', content: title });
     this.metaService.updateTag({ property: 'og:description', content: description });
     this.metaService.updateTag({ property: 'og:url', content: url });
-    if (imageUrl) {
-      this.metaService.updateTag({ property: 'og:image', content: imageUrl });
-    }
+    this.metaService.updateTag({ property: 'og:image', content: imageUrl });
+    this.metaService.updateTag({ property: 'og:image:width', content: '1200' });
+    this.metaService.updateTag({ property: 'og:image:height', content: '630' });
     this.metaService.updateTag({ name: 'twitter:card', content: 'summary_large_image' });
     this.metaService.updateTag({ name: 'twitter:title', content: title });
     this.metaService.updateTag({ name: 'twitter:description', content: description });
-    if (imageUrl) {
-      this.metaService.updateTag({ name: 'twitter:image', content: imageUrl });
-    }
+    this.metaService.updateTag({ name: 'twitter:image', content: imageUrl });
     this.metaService.updateTag({ property: 'article:published_time', content: post.publishedAt });
   }
 

--- a/alissonlimabr/src/app/components/particles-animation/ParticlesAnimationComponent.ts
+++ b/alissonlimabr/src/app/components/particles-animation/ParticlesAnimationComponent.ts
@@ -25,6 +25,7 @@ import { loadSlim } from '@tsparticles/slim';
 })
 export class ParticlesAnimationComponent implements OnInit {
   id = 'tsparticles';
+  readonly isBrowser: boolean;
   particlesOptions = {
     fpsLimit: 24,
     interactivity: {
@@ -51,10 +52,12 @@ export class ParticlesAnimationComponent implements OnInit {
   constructor(
     private readonly ngParticlesService: NgParticlesService,
     @Inject(PLATFORM_ID) private platformId: Object
-  ) {}
+  ) {
+    this.isBrowser = isPlatformBrowser(this.platformId);
+  }
 
   async ngOnInit(): Promise<void> {
-    if (isPlatformBrowser(this.platformId)) {
+    if (this.isBrowser) {
       await this.loadParticles();
     }
   }

--- a/alissonlimabr/src/app/components/particles-animation/particles-animation.component.html
+++ b/alissonlimabr/src/app/components/particles-animation/particles-animation.component.html
@@ -1,1 +1,3 @@
-<ngx-particles [id]="id" [options]="particlesOptions" [@fadeIn]></ngx-particles>
+@if (isBrowser) {
+  <ngx-particles [id]="id" [options]="particlesOptions" [@fadeIn]></ngx-particles>
+}

--- a/alissonlimabr/src/app/portfolio/home/home.component.html
+++ b/alissonlimabr/src/app/portfolio/home/home.component.html
@@ -87,7 +87,7 @@
         </p>
         <p>
           Ao longo da minha trajetória, também trabalhei com Java, Spring Boot, AWS e projetos
-          estratégicos para clientes como SEFAZ/AC e Caixa Econômica Federal. Sou graduado em
+          estratégicos para clientes como SEFAZ/AC. Sou graduado em
           Análise e Desenvolvimento de Sistemas, com especializações em Engenharia de Software
           e Gestão de Projetos.
         </p>
@@ -108,7 +108,7 @@
         </div>
         <div class="stat-card" appSpotlight>
           <span class="stat-card-value stat-card-value--text">Projetos reais</span>
-          <span class="stat-card-label">IFAC, SEFAZ/AC, Caixa e produtos institucionais</span>
+          <span class="stat-card-label">IFAC, SEFAZ/AC e produtos institucionais</span>
         </div>
       </aside>
     </div>

--- a/alissonlimabr/src/app/shared/icon.component.ts
+++ b/alissonlimabr/src/app/shared/icon.component.ts
@@ -6,7 +6,9 @@ import {
   signal,
   effect,
   inject,
+  PLATFORM_ID,
 } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
@@ -48,9 +50,13 @@ export class IconComponent {
 
   private readonly http = inject(HttpClient);
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   constructor() {
     effect(() => {
+      if (!this.isBrowser) {
+        return;
+      }
       const name = this.name();
       const folder = this.folder();
       const cacheKey = `${folder}/${name}`;

--- a/alissonlimabr/src/main.ts
+++ b/alissonlimabr/src/main.ts
@@ -3,7 +3,7 @@ import { importProvidersFrom } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppRoutingModule } from './app/app-routing.module';
 import Clarity from '@microsoft/clarity';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
 import { AppComponent } from './app/app.component';
 
 // Bootstrap standalone
@@ -11,7 +11,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     importProvidersFrom(BrowserAnimationsModule),
     importProvidersFrom(AppRoutingModule),
-    provideHttpClient(withInterceptorsFromDi())
+    provideHttpClient(withFetch(), withInterceptorsFromDi())
   ]
 })
   .then(() => Clarity.init('pexxkhasj2'))

--- a/alissonlimabr/vercel.json
+++ b/alissonlimabr/vercel.json
@@ -1,7 +1,6 @@
 {
-  "buildCommand": "node scripts/generate-env.mjs && node scripts/generate-rss.mjs && npm run build",
+  "buildCommand": "node scripts/generate-env.mjs && node scripts/generate-rss.mjs && npm run prerender",
   "outputDirectory": "dist/alissonlimabr/browser",
-  "rewrites": [{ "source": "/((?!assets/|rss\\.xml).*)", "destination": "/index.html" }],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Problema

Durante os testes das páginas do blog, foi identificado que os links dos posts exibiam a imagem padrão do portfólio ao serem compartilhados no LinkedIn e WhatsApp, em vez da imagem SEO ou da capa cadastrada no Sanity.

A origem do problema está nas alterações de SSR incorporadas no PR [#26](https://github.com/alissonlimabr/portfolio/pull/26): o server.ts responsável por renderizar as rotas foi removido, pois se pensou não ser mais necessário e o deploy da Vercel passou a publicar apenas o build comum da aplicação.

Com isso, as páginas do blog não entregavam um HTML inicial específico para cada post, mantendo a imagem padrão do portfólio.

## Correção e ajustes

- Gera automaticamente as rotas de posts e categorias cadastradas no Sanity.
- Gera páginas HTML estáticas para essas rotas durante o build.
- Atualiza o deploy da Vercel para publicar os HTMLs já prontos.
- Ajusta componentes incompatíveis com a renderização no servidor.
- Define a imagem de compartilhamento dos posts nesta ordem:
  - imagem SEO;
  - imagem de capa;
  - imagem padrão do portfólio.

## Validação

- Problema identificado durante os testes das páginas do blog.
- Posts validados com título, link e imagem corretos para compartilhamento.
- Posts sem imagem SEO utilizando corretamente a imagem de capa.

## Observação

O prerender padrão configurado no projeto também apresentou falha com a versão atual do Angular. Por isso, esta correção utiliza uma geração estática própria para as páginas do blog.